### PR TITLE
display full seed

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -60,7 +60,7 @@ minetest.register_chatcommand("find_strongholds",{
 		if poi then
 			poi.display(sp[1],"Closest stronghold")
 		end
-		minetest.display_chat_message("strongholds for seed "..seed..":")
+		minetest.display_chat_message("strongholds for seed "..string.format("%18.0f",seed)..":")
 		minetest.display_chat_message("(sorted by distance from player)")
 		local l = ""
 		for _,v in ipairs(sp) do


### PR DESCRIPTION
currently, your clientmod displays a scientific notation for seeds of a certain length (used by 99.90% of people). This pull request changes that to display the full decimal number...

Fun fact:; Here you can also notice the slight mistake in the way dragonfire provides the seed to clientmods, it takes the unsigned 64 bit number and pushes it into a lua double, ignoring that the last few bits of the seed get totally screwed up, the only reason this works in the care of mineclone strongholds is that the minetest api for servers provides provides the unsigned 64 bit number as a string to mods, and mineclone does a similar mistake by just doing tonumber() on that

To correct this mistake in the c++ version, I had to do that on purpose: https://github.com/dragonfireclient/dragonfireclient/pull/60/files#diff-636f07aea7410bc00f17b2c990ee5609c1ef6d92664a21f3747b73f98498a7deR25